### PR TITLE
Fix typespec to use term() for key parameter in leaky_bucket and toke…

### DIFF
--- a/lib/hammer/mnesia/leaky_bucket.ex
+++ b/lib/hammer/mnesia/leaky_bucket.ex
@@ -103,7 +103,7 @@ defmodule Hammer.Mnesia.LeakyBucket do
   """
   @spec hit(
           table :: atom(),
-          key :: String.t(),
+          key :: term(),
           leak_rate :: pos_integer(),
           capacity :: pos_integer(),
           cost :: pos_integer()
@@ -149,7 +149,7 @@ defmodule Hammer.Mnesia.LeakyBucket do
   @doc """
   Returns the current level of the bucket for a given key.
   """
-  @spec get(table :: atom(), key :: String.t()) :: non_neg_integer()
+  @spec get(table :: atom(), key :: term()) :: non_neg_integer()
   def get(table, key) do
     result =
       :mnesia.transaction(fn ->

--- a/lib/hammer/mnesia/token_bucket.ex
+++ b/lib/hammer/mnesia/token_bucket.ex
@@ -103,7 +103,7 @@ defmodule Hammer.Mnesia.TokenBucket do
   @doc false
   @spec hit(
           table :: atom(),
-          key :: String.t(),
+          key :: term(),
           refill_rate :: pos_integer(),
           capacity :: pos_integer(),
           cost :: pos_integer()
@@ -151,7 +151,7 @@ defmodule Hammer.Mnesia.TokenBucket do
   @doc """
   Returns the current level of the bucket for a given key.
   """
-  @spec get(table :: atom(), key :: String.t()) :: non_neg_integer()
+  @spec get(table :: atom(), key :: term()) :: non_neg_integer()
   def get(table, key) do
     result =
       :mnesia.transaction(fn ->

--- a/test/hammer/mnesia/leaky_bucket_test.exs
+++ b/test/hammer/mnesia/leaky_bucket_test.exs
@@ -78,4 +78,31 @@ defmodule Hammer.Mnesia.LeakyBucketTest do
       assert RateLimitLeakyBucket.get(key) == 3
     end
   end
+
+  describe "non-string keys" do
+    test "works with atom keys" do
+      leak_rate = :timer.seconds(10)
+      capacity = 10
+
+      assert {:allow, 1} = RateLimitLeakyBucket.hit(:atom_key, leak_rate, capacity)
+      assert RateLimitLeakyBucket.get(:atom_key) == 1
+    end
+
+    test "works with tuple keys" do
+      leak_rate = :timer.seconds(10)
+      capacity = 10
+      tuple_key = {:user, 123}
+
+      assert {:allow, 1} = RateLimitLeakyBucket.hit(tuple_key, leak_rate, capacity)
+      assert RateLimitLeakyBucket.get(tuple_key) == 1
+    end
+
+    test "works with integer keys" do
+      leak_rate = :timer.seconds(10)
+      capacity = 10
+
+      assert {:allow, 1} = RateLimitLeakyBucket.hit(123, leak_rate, capacity)
+      assert RateLimitLeakyBucket.get(123) == 1
+    end
+  end
 end

--- a/test/hammer/mnesia/token_bucket_test.exs
+++ b/test/hammer/mnesia/token_bucket_test.exs
@@ -81,4 +81,31 @@ defmodule Hammer.Redis.TokenBucketTest do
       assert RateLimitTokenBucket.get(key) == 3
     end
   end
+
+  describe "non-string keys" do
+    test "works with atom keys" do
+      refill_rate = :timer.seconds(10)
+      capacity = 10
+
+      assert {:allow, 9} = RateLimitTokenBucket.hit(:atom_key, refill_rate, capacity, 1)
+      assert RateLimitTokenBucket.get(:atom_key) == 9
+    end
+
+    test "works with tuple keys" do
+      refill_rate = :timer.seconds(10)
+      capacity = 10
+      tuple_key = {:user, 123}
+
+      assert {:allow, 9} = RateLimitTokenBucket.hit(tuple_key, refill_rate, capacity, 1)
+      assert RateLimitTokenBucket.get(tuple_key) == 9
+    end
+
+    test "works with integer keys" do
+      refill_rate = :timer.seconds(10)
+      capacity = 10
+
+      assert {:allow, 9} = RateLimitTokenBucket.hit(123, refill_rate, capacity, 1)
+      assert RateLimitTokenBucket.get(123) == 9
+    end
+  end
 end


### PR DESCRIPTION
…n_bucket

Updates key parameter from String.t() to term() to match fix_window.ex and allow flexible key types. Adds tests for atom, tuple, and integer keys.