### PR TITLE
Remove 'Getting Help' section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,3 @@ end
 ## Documentation
 
 On hexdocs: [https://hexdocs.pm/hammer_backend_mnesia/](https://hexdocs.pm/hammer_backend_mnesia/)
-
-## Getting Help
-
-If you're having trouble, either open an issue on this repo, or reach out to the
-maintainers ([@shanekilkelly](https://twitter.com/shanekilkelly)) on Twitter.


### PR DESCRIPTION
Update to match the pattern in other project READMEs, and removes reference to obsolete twitter account